### PR TITLE
feat: numeric keypad for OTP input field

### DIFF
--- a/pages/login.html
+++ b/pages/login.html
@@ -497,6 +497,9 @@
                       placeholder="Type the sign in code we emailed you"
                       value=""
                       autocomplete="off"
+                      inputmode="numeric"
+                      pattern="[0-9]*"
+                      type="text"
                     />
                   </div>
                   <div class="button-holder">


### PR DESCRIPTION
This was something that bugged me out a lot yesterday when working on the mobile auth as the numbers are very small on the default keyboard so the changes in this PR shows a numeric keypad for entering the OTP received during the passwordless login. With a numeric keypad it's a lot easier and faster when typing the OTP.

The `pattern` attribute is needed for supporting iOS devices - https://developer.apple.com/library/archive/documentation/StringsTextFonts/Conceptual/TextAndWebiPhoneOS/KeyboardManagement/KeyboardManagement.html